### PR TITLE
Add plugin to handle http matchmaking handshake

### DIFF
--- a/Reactor.Impostor.Http/ClientModsHeader.cs
+++ b/Reactor.Impostor.Http/ClientModsHeader.cs
@@ -1,0 +1,85 @@
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Primitives;
+using Reactor.Networking;
+
+namespace Reactor.Impostor.Http;
+
+/// <summary>
+/// Add a Client-Mods-Processed header to all requests with a valid header.
+/// </summary>
+public class ClientModsHeader : IMiddleware
+{
+    private readonly ILogger<ClientModsHeader> _logger;
+
+    /// <param name="logger">Logger for handshake issues</param>
+    public ClientModsHeader(ILogger<ClientModsHeader> logger)
+    {
+        this._logger = logger;
+    }
+
+    /// <inheritdoc/>
+    public async Task InvokeAsync(HttpContext context, RequestDelegate next)
+    {
+        var clientInfo = GetReactorClientInfo(context.Request.Headers["Client-Mods"]);
+
+        if (clientInfo != null)
+        {
+            context.Response.Headers.Add("Client-Mods-Processed", "yes");
+            context.Features.Set(clientInfo);
+        }
+
+        await next(context);
+    }
+
+    private ReactorClientInfo? GetReactorClientInfo(StringValues headers)
+    {
+        if (headers.Count == 1)
+        {
+            return BuildReactorClientInfo(headers[0]);
+        }
+        else if (headers.Count > 1)
+        {
+            this._logger.LogError("Client sent over {} headers, expected 0 or 1", headers.Count);
+        }
+        return null;
+    }
+
+    private ReactorClientInfo? BuildReactorClientInfo(string str)
+    {
+        var parts = str.Split(';');
+        if (parts.Length < 2)
+        {
+            this._logger.LogError("Expected a version and a mod count");
+            return null;
+        }
+
+        if (parts[0] != "1")
+        {
+            this._logger.LogError("Expected version \"1\", got \"{}\"", parts[0]);
+            return null;
+        }
+
+        var modCount = int.Parse(parts[1]);
+        if (parts.Length - 2 != modCount)
+        {
+            this._logger.LogError("Expected \"{}\" mods, got \"{}\"", modCount, parts.Length - 2);
+            return null;
+        }
+
+        var clientInfo = new ReactorClientInfo(ReactorProtocolVersion.Initial, modCount);
+        for (uint i = 2; i < parts.Length; i++)
+        {
+            var modParts = parts[i].Split("=");
+            if (modParts.Length != 2)
+            {
+                this._logger.LogError("Expected exactly one \"=\" in \"{}\"", parts[i]);
+                return null;
+            }
+
+            clientInfo.Mods.Add(new Mod(i, modParts[0], modParts[1], PluginSide.Both));
+        }
+
+        return clientInfo;
+    }
+}

--- a/Reactor.Impostor.Http/Reactor.Impostor.Http.csproj
+++ b/Reactor.Impostor.Http/Reactor.Impostor.Http.csproj
@@ -1,0 +1,25 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+		<OutputType>Library</OutputType>
+    <TargetFramework>net6.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+		<RestorePackagesWithLockFile>true</RestorePackagesWithLockFile>
+		<GenerateDocumentationFile>true</GenerateDocumentationFile>
+		<EnableNETAnalyzers>true</EnableNETAnalyzers>
+		<Description>Make sure people joining an Impostor room have compatible mods</Description>
+		<Authors>miniduikboot</Authors>
+  </PropertyGroup>
+
+	<ItemGroup>
+		<PackageReference Include="Impostor.Api" Version="1.6.0" />
+    <PackageReference Include="Impostor.Http" Version="0.1.0" />
+		<ProjectReference Include="..\Reactor.Impostor\Reactor.Impostor.csproj">
+			<Private>false</Private>
+		</ProjectReference>
+		
+		<!-- Code style libraries -->
+		<PackageReference Include="SonarAnalyzer.CSharp" Version="8.40.0.48530" PrivateAssets="all" />
+	</ItemGroup>
+</Project>

--- a/Reactor.Impostor.Http/ReactorHandshakeFilter.cs
+++ b/Reactor.Impostor.Http/ReactorHandshakeFilter.cs
@@ -1,0 +1,123 @@
+using Impostor.Api.Games;
+using Impostor.Http;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.Logging;
+using Reactor.Networking;
+
+namespace Reactor.Impostor.Http;
+/**
+ * <summary>
+ * Check if players have the same mods using the Reactor Handshake.
+ * </summary>
+ */
+public class ReactorHandshakeFilter : IListingFilter
+{
+    private readonly ILogger<ReactorHandshakeFilter> logger;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="ReactorHandshakeFilter"/> class.
+    /// </summary>
+    /// <param name="logger">Logger for this filter.</param>
+    public ReactorHandshakeFilter(ILogger<ReactorHandshakeFilter> logger)
+    {
+        this.logger = logger;
+    }
+
+    /// <inheritdoc/>
+    public Func<IGame, bool> GetFilter(HttpContext context)
+    {
+        var headers = context.Request.Headers["Client-Mods"];
+
+        // If no header was included, this is a vanilla game
+        if (headers.Count == 0)
+        {
+            return game =>
+            {
+                var host = game.Host;
+                if (host == null)
+                {
+                    return true;
+                }
+
+                var reactor = host.Client.GetReactor();
+
+                // Only allow if no handshake was present or only client side mods are present
+                return reactor == null || !reactor.Mods.Any(x => x.Side == PluginSide.Both);
+            };
+        }
+        else if (headers.Count == 1)
+        {
+            var myClientInfo = this.BuildReactorClientInfo(headers[0]);
+            if (myClientInfo == null)
+            {
+                this.logger.LogError("Couldn't parse ReactorClientHttp from string, \"{}\"", headers[0]);
+                return game => false;
+            }
+
+            context.Response.Headers.Add("Client-Mods-Processed", "yes");
+
+            return game =>
+            {
+                var host = game.Host;
+                if (host == null)
+                {
+                    return false;
+                }
+
+                var hostClientInfo = host.Client.GetReactor();
+                if (hostClientInfo == null)
+                {
+                    return false;
+                }
+
+                var hostMods = hostClientInfo.Mods.Where(m => m.Side == PluginSide.Both);
+                return hostMods.Count() == myClientInfo.ModCount && hostMods.All(m => myClientInfo.Mods.Contains(m));
+            };
+        }
+        else
+        {
+            this.logger.LogError("Client sent over {} headers, expected 0 or 1", headers.Count);
+            return game => false;
+        }
+
+        throw new NotImplementedException();
+    }
+
+    private ReactorClientInfo? BuildReactorClientInfo(string str)
+    {
+        string[] parts = str.Split(';');
+        if (parts.Length < 2)
+        {
+            this.logger.LogError("Expected a version and a mod count");
+            return null;
+        }
+
+        if (parts[0] != "1")
+        {
+            this.logger.LogError("Expected version \"1\", got \"{}\"", parts[0]);
+            return null;
+        }
+
+        var modCount = int.Parse(parts[1]);
+        if (parts.Length - 2 != modCount)
+        {
+            this.logger.LogError("Expected \"{}\" mods, got \"{}\"", modCount, parts.Length - 2);
+            return null;
+        }
+
+        var clientInfo = new ReactorClientInfo(ReactorProtocolVersion.Initial, modCount);
+        for (uint i = 2; i < parts.Length; i++)
+        {
+            var modParts = parts[i].Split("=");
+            if (modParts.Length != 2)
+            {
+                this.logger.LogError("Expected exactly one \"=\" in \"{}\"", parts[i]);
+                return null;
+            }
+
+            clientInfo.Mods.Add(new Mod(i, modParts[0], modParts[1], PluginSide.Both));
+        }
+
+        return clientInfo;
+    }
+}

--- a/Reactor.Impostor.Http/ReactorHttpPlugin.cs
+++ b/Reactor.Impostor.Http/ReactorHttpPlugin.cs
@@ -5,8 +5,8 @@ namespace Reactor.Impostor.Http;
 /// <summary>
 /// Plugin that checks the Reactor HTTP handshake for Impostor.Http.
 /// </summary>
-[ImpostorPlugin("at.duikbo.http.reactor")]
-[ImpostorDependency("at.duikbo.http", DependencyType.HardDependency)]
+[ImpostorPlugin("gg.reactor.http")]
+[ImpostorDependency("gg.impostor.http", DependencyType.HardDependency)]
 [ImpostorDependency("gg.reactor.impostor", DependencyType.HardDependency)]
 public class ReactorHttpPlugin : PluginBase
 {

--- a/Reactor.Impostor.Http/ReactorHttpPlugin.cs
+++ b/Reactor.Impostor.Http/ReactorHttpPlugin.cs
@@ -1,0 +1,13 @@
+using Impostor.Api.Plugins;
+
+namespace Reactor.Impostor.Http;
+
+/// <summary>
+/// Plugin that checks the Reactor HTTP handshake for Impostor.Http.
+/// </summary>
+[ImpostorPlugin("at.duikbo.http.reactor")]
+[ImpostorDependency("at.duikbo.http", DependencyType.HardDependency)]
+[ImpostorDependency("gg.reactor.impostor", DependencyType.HardDependency)]
+public class ReactorHttpPlugin : PluginBase
+{
+}

--- a/Reactor.Impostor.Http/ReactorHttpPluginStartup.cs
+++ b/Reactor.Impostor.Http/ReactorHttpPluginStartup.cs
@@ -2,6 +2,7 @@ using Impostor.Api.Plugins;
 using Impostor.Http;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
+using Microsoft.AspNetCore.Builder;
 
 namespace Reactor.Impostor.Http;
 /**
@@ -21,5 +22,11 @@ public class ReactorHttpPluginStartup : IPluginStartup
     public void ConfigureServices(IServiceCollection services)
     {
         services.AddSingleton<IListingFilter, ReactorHandshakeFilter>();
+        services.AddSingleton<ClientModsHeader>();
+
+        ImpostorHttpPluginStartup.OnWebHostConfigure += (app) =>
+        {
+            app.UseMiddleware<ClientModsHeader>();
+        };
     }
 }

--- a/Reactor.Impostor.Http/ReactorHttpPluginStartup.cs
+++ b/Reactor.Impostor.Http/ReactorHttpPluginStartup.cs
@@ -1,0 +1,25 @@
+using Impostor.Api.Plugins;
+using Impostor.Http;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+
+namespace Reactor.Impostor.Http;
+/**
+ * <summary>
+ * Register the ReactorHandshakeFilter.
+ * </summary>
+ */
+public class ReactorHttpPluginStartup : IPluginStartup
+{
+    /// <inheritdoc/>
+    public void ConfigureHost(IHostBuilder host)
+    {
+        // Not used
+    }
+
+    /// <inheritdoc/>
+    public void ConfigureServices(IServiceCollection services)
+    {
+        services.AddSingleton<IListingFilter, ReactorHandshakeFilter>();
+    }
+}

--- a/Reactor.Impostor.Http/packages.lock.json
+++ b/Reactor.Impostor.Http/packages.lock.json
@@ -1,0 +1,79 @@
+{
+  "version": 1,
+  "dependencies": {
+    "net6.0": {
+      "Impostor.Api": {
+        "type": "Direct",
+        "requested": "[1.6.0, )",
+        "resolved": "1.6.0",
+        "contentHash": "UPD7TzP/Zb+RBrgQ5Ljmt3+z3z9ZpvCagBPWAdiRRlRVwPP4Hv+df5xdWHPFSzmV8QMZI+0cHpWvQ7Ls5n6e0g==",
+        "dependencies": {
+          "Microsoft.Extensions.Hosting.Abstractions": "5.0.0",
+          "Microsoft.Extensions.Logging.Abstractions": "5.0.0"
+        }
+      },
+      "Impostor.Http": {
+        "type": "Direct",
+        "requested": "[0.1.0, )",
+        "resolved": "0.1.0",
+        "contentHash": "YKhI0dkvAHHCGAyP6vA2i0FmqDsCDk8dGZN2uYJPBForU7WnR7QGBMPlA4554X6Z7rY0Of7jTao1mCV2lrurGQ==",
+        "dependencies": {
+          "Impostor.Api": "1.6.0"
+        }
+      },
+      "SonarAnalyzer.CSharp": {
+        "type": "Direct",
+        "requested": "[8.40.0.48530, )",
+        "resolved": "8.40.0.48530",
+        "contentHash": "ZxON0c0ZUF7snuaEmGWczPQ5OHyYRzCHHwZ5FlRoK4kVwqH0CawAxto8Xx8iJXb9vBX1kbVK4t14+WP4hJcuVg=="
+      },
+      "Microsoft.Extensions.Configuration.Abstractions": {
+        "type": "Transitive",
+        "resolved": "5.0.0",
+        "contentHash": "ETjSBHMp3OAZ4HxGQYpwyGsD8Sw5FegQXphi0rpoGMT74S4+I2mm7XJEswwn59XAaKOzC15oDSOWEE8SzDCd6Q==",
+        "dependencies": {
+          "Microsoft.Extensions.Primitives": "5.0.0"
+        }
+      },
+      "Microsoft.Extensions.DependencyInjection.Abstractions": {
+        "type": "Transitive",
+        "resolved": "5.0.0",
+        "contentHash": "ORj7Zh81gC69TyvmcUm9tSzytcy8AVousi+IVRAI8nLieQjOFryRusSFh7+aLk16FN9pQNqJAiMd7BTKINK0kA=="
+      },
+      "Microsoft.Extensions.FileProviders.Abstractions": {
+        "type": "Transitive",
+        "resolved": "5.0.0",
+        "contentHash": "iuZIiZ3mteEb+nsUqpGXKx2cGF+cv6gWPd5jqQI4hzqdiJ6I94ddLjKhQOuRW1lueHwocIw30xbSHGhQj0zjdQ==",
+        "dependencies": {
+          "Microsoft.Extensions.Primitives": "5.0.0"
+        }
+      },
+      "Microsoft.Extensions.Hosting.Abstractions": {
+        "type": "Transitive",
+        "resolved": "5.0.0",
+        "contentHash": "cbUOCePYBl1UhM+N2zmDSUyJ6cODulbtUd9gEzMFIK3RQDtP/gJsE08oLcBSXH3Q1RAQ0ex7OAB3HeTKB9bXpg==",
+        "dependencies": {
+          "Microsoft.Extensions.Configuration.Abstractions": "5.0.0",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "5.0.0",
+          "Microsoft.Extensions.FileProviders.Abstractions": "5.0.0"
+        }
+      },
+      "Microsoft.Extensions.Logging.Abstractions": {
+        "type": "Transitive",
+        "resolved": "5.0.0",
+        "contentHash": "NxP6ahFcBnnSfwNBi2KH2Oz8Xl5Sm2krjId/jRR3I7teFphwiUoUeZPwTNA21EX+5PtjqmyAvKaOeBXcJjcH/w=="
+      },
+      "Microsoft.Extensions.Primitives": {
+        "type": "Transitive",
+        "resolved": "5.0.0",
+        "contentHash": "cI/VWn9G1fghXrNDagX9nYaaB/nokkZn0HYAawGaELQrl8InSezfe9OnfPZLcJq3esXxygh3hkq2c3qoV3SDyQ=="
+      },
+      "reactor.impostor": {
+        "type": "Project",
+        "dependencies": {
+          "Impostor.Api": "1.6.0"
+        }
+      }
+    }
+  }
+}

--- a/Reactor.Impostor.sln
+++ b/Reactor.Impostor.sln
@@ -1,8 +1,11 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
+# 
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Reactor.Impostor", "Reactor.Impostor\Reactor.Impostor.csproj", "{1522BD93-2A54-4B2C-8137-179978CD8D98}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Reactor.Impostor.Example", "Reactor.Impostor.Example\Reactor.Impostor.Example.csproj", "{9CA8D857-B2B8-4A82-9622-9E87281EC6E3}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Reactor.Impostor.Http", "Reactor.Impostor.Http\Reactor.Impostor.Http.csproj", "{73A555DA-C1E2-4458-89D1-4CF4FEF06F59}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -18,5 +21,9 @@ Global
 		{9CA8D857-B2B8-4A82-9622-9E87281EC6E3}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{9CA8D857-B2B8-4A82-9622-9E87281EC6E3}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{9CA8D857-B2B8-4A82-9622-9E87281EC6E3}.Release|Any CPU.Build.0 = Release|Any CPU
+		{73A555DA-C1E2-4458-89D1-4CF4FEF06F59}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{73A555DA-C1E2-4458-89D1-4CF4FEF06F59}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{73A555DA-C1E2-4458-89D1-4CF4FEF06F59}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{73A555DA-C1E2-4458-89D1-4CF4FEF06F59}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 EndGlobal


### PR DESCRIPTION
This handshake makes it possible to filter games that are presented to
users when using the http matchmaking feature added to recent Among Us versions.

Counterpart of https://github.com/NuclearPowered/Reactor/commit/3579ecb89e65fad0e51e6f4bf990d5d80f5a37d0